### PR TITLE
fix: replace 5 bare excepts with except Exception

### DIFF
--- a/src/liveportrait/util.py
+++ b/src/liveportrait/util.py
@@ -373,7 +373,7 @@ class LayerNorm(nn.Module):
                     
                     target_device = target_tensor.device
                     target_dtype = target_tensor.dtype
-                except:
+                except Exception:
                     target_device = param.device
                     target_dtype = param.dtype
 

--- a/src/modeling/engine_model.py
+++ b/src/modeling/engine_model.py
@@ -124,7 +124,7 @@ class EngineModel:
                     trt.volume(self.output_shapes[name]), dtype=trt.nptype(self.output_dtypes[name])
                 ) for name in self.output_names
             } # 分配 page-locked host 内存以存储输出
-        except:
+        except Exception:
             self.ctx.pop()
             raise Exception("CUDA Initialization Failed!")
         self.ctx.pop()
@@ -296,7 +296,7 @@ class EngineModel:
         try:
             for name in self.input_names:
                 self.context.set_tensor_address(name, int(self.dinputs[name]))
-        except:
+        except Exception:
             self.ctx.pop()
             if not(self.extra_lock is None):
                 self.extra_lock.release()

--- a/src/models/unet_2d_decoder.py
+++ b/src/models/unet_2d_decoder.py
@@ -490,7 +490,7 @@ class UNetDec_ControlNetModel(ModelMixin, ConfigMixin, FromOriginalControlNetMix
                 try:
                     # print('Successfully initializing ControlNet!', name, tensor.shape, src_tensors[name].shape)
                     tensor.copy_(src_tensors[name].detach())
-                except:
+                except Exception:
                     # print('Mismatch occured in initializing ControlNet!', name, tensor.shape, src_tensors[name].shape)
                     # TODO: 确保所有upblock参数有初始化
                     if tensor.dim() == 1:

--- a/src/utils/util.py
+++ b/src/utils/util.py
@@ -61,7 +61,7 @@ def create_code_snapshot(root, dst_path, extensions=(".py", ".h", ".cpp", ".cu",
                 try:
                     tar.add(path.as_posix(), arcname=path.relative_to(
                         root).as_posix(), recursive=True)
-                except:
+                except Exception:
                     print(path)
                     assert False, 'Error occur in create_code_snapshot'
 


### PR DESCRIPTION
## Summary

Replace 5 bare `except:` clauses with `except Exception:` across 4 files.

## Why

Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, which can mask real errors and prevent clean process termination. `except Exception:` preserves error-suppression behavior while allowing system-level exceptions to propagate.

## Changes

- `src/liveportrait/util.py` (1 site)
- `src/modeling/engine_model.py` (2 sites)
- `src/models/unet_2d_decoder.py` (1 site)
- `src/utils/util.py` (1 site)